### PR TITLE
Add Cesium as Bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "angular": "~1.3.8",
-    "cesiumjs": "^1.22.0"
+    "cesiumjs": "^1.22.0",
     "observable-collection": "~0.0.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "angular": "~1.3.8",
+    "cesiumjs": "^1.22.0"
     "observable-collection": "~0.0.1"
   }
 }


### PR DESCRIPTION
GitHub user @mixxen provides Cesium as a bower dependency and keeps it relatively up-to-date. I've added it as a dependency in `bower.json` to ease development for the client.

See https://github.com/mixxen/cesiumjs
