### PR TITLE
Add support for newer versions of Angular

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.3.8",
+    "angular": "^1.3.8",
     "observable-collection": "~0.0.1"
   }
 }


### PR DESCRIPTION
When using angular-cesium with newer versions of Angular, bower will complain and ask you to select between different Angular versions. This change should eliminate that ambiguity.
